### PR TITLE
DRY Template Registration

### DIFF
--- a/lib/html_pipeline_rails.rb
+++ b/lib/html_pipeline_rails.rb
@@ -13,6 +13,4 @@ module HtmlPipelineRails
   end
 end
 
-ActionView::Template.register_template_handler(:md, HtmlPipelineRails::Handler.new)
-ActionView::Template.register_template_handler(:mdown, HtmlPipelineRails::Handler.new)
-ActionView::Template.register_template_handler(:markdown, HtmlPipelineRails::Handler.new)
+ActionView::Template.register_template_handler(:md, :mdown, :markdown, HtmlPipelineRails::Handler.new)

--- a/spec/markdown_spec.rb
+++ b/spec/markdown_spec.rb
@@ -46,4 +46,16 @@ describe "markdown views" do
     result = @view.render(inline: template, type: :md)
     expect(result).to eq('<p><a href="/afeld" class="user-mention">@afeld</a></p>')
   end
+
+  it "inline rendering with mdown extension" do
+    template = '# A Heading'
+    result = @view.render(inline: template, type: :mdown)
+    expect(result).to eq('<h1>A Heading</h1>')
+  end
+
+  it "inline rendering with markdown extension" do
+    template = '# A Heading'
+    result = @view.render(inline: template, type: :markdown)
+    expect(result).to eq('<h1>A Heading</h1>')
+  end
 end


### PR DESCRIPTION
[ActionView::Template.register_template_handler](https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/handlers.rb#L23-L33) can receive multiple extensions.

@afeld, this is a really cool project.  We should add it to the `HTML::Pipeline` README. What do you think @jch?  
