### PR TITLE
Update deprecated markdown dependency

### DIFF
--- a/html_pipeline_rails.gemspec
+++ b/html_pipeline_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "github-markdown"
+  spec.add_dependency "commonmarker"
   spec.add_dependency "html-pipeline"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
https://github.com/github/github-markdown has been depracated. Switch
to using the commonmarker gem.